### PR TITLE
engine: sparse universes; drive orders hole-free in q13

### DIFF
--- a/rust/src/engine.rs
+++ b/rust/src/engine.rs
@@ -763,9 +763,9 @@ pub struct Bitset<D: Dense = usize> {
 impl<D: Dense> Bitset<D> {
     /// `u` is anything that resolves to the universe — the `Universe` value
     /// itself or a schema-generated universe handle (`orders`).
-    pub fn empty(u: impl IntoQuery<Q = Universe<D>>) -> Self {
-        let u = u.iq();
-        Bitset { bs: vec![0u64; u.n.div_ceil(64)], n: u.n, _d: PhantomData }
+    pub fn empty<U: IntoQuery>(u: U) -> Self where U::Q: UnivSize<D> {
+        let n = u.iq().univ_n();
+        Bitset { bs: vec![0u64; n.div_ceil(64)], n, _d: PhantomData }
     }
     /// A bitset over `u`, driven from `q`: set a bit at each emitted VALUE.
     /// Identity relations send their keys through the value slot, so one
@@ -774,8 +774,8 @@ impl<D: Dense> Bitset<D> {
     /// including `NO_ID` hole fills — are dropped by the `set` guard.
     /// Both arguments resolve via `IntoQuery`: universe handles for `u`,
     /// plans (usually by reference) or leaf handles for `q`.
-    pub fn over<Q: IntoQuery>(u: impl IntoQuery<Q = Universe<D>>, q: Q) -> Self
-    where Q::Q: Drive<R = D> {
+    pub fn over<U: IntoQuery, Q: IntoQuery>(u: U, q: Q) -> Self
+    where U::Q: UnivSize<D>, Q::Q: Drive<R = D> {
         let mut b = Self::empty(u);
         q.iq().drive(|_, c| b.set(c));
         b
@@ -818,6 +818,61 @@ impl<D: Dense> Probe for Bitset<D> {
         self.bs.get(i / 64).is_some_and(|&w| (w >> (i % 64)) & 1 == 1)
     }
 }
+
+impl<D: Dense> Bitset<D> {
+    /// Validity mask for a SPARSE entity: bit set for each slot `0..fk.len()`
+    /// whose foreign key is a real target (`!= NONE`). The dense id space of a
+    /// sparse entity (e.g. `orders` over sparse orderkeys) has hole slots whose
+    /// FK columns are `NO_ID`; this enumerates the live ones. `D` is the entity
+    /// id, `T` the FK target id.
+    pub fn validity<T: Dense>(fk: &[T]) -> Self {
+        let mut b = Self::empty(Universe::<D>::new(fk.len()));
+        for (i, &v) in fk.iter().enumerate() {
+            if v != T::NONE { b.set(D::from_idx(i)); }
+        }
+        b
+    }
+}
+
+// ===== SparseUniverse — `Universe` with a validity mask =================
+// A dense id space `0..n` that carries holes (e.g. `orders` over sparse
+// orderkeys). DRIVE enumerates only live slots (word-scan the mask); PROBE /
+// MEMBER keep the plain range check and IGNORE the mask. That asymmetry is
+// sound and deliberate: a hole id never reaches a probe (probe keys come from
+// FKs — always real — or from the masked drive itself), and `NO_ID` is already
+// out of range. So sparse universes pay the mask only on drive (where it's the
+// whole point) and probe branch-for-branch identically to a dense `Universe`.
+//
+// It is a SEPARATE TYPE from `Universe` on purpose: drive dispatch is at
+// compile time, so the dense `Universe::drive` loop is untouched — no shared
+// branch to de-optimise its closure inlining.
+
+pub struct SparseUniverse<D: Dense> {
+    pub n: usize,
+    pub valid: &'static Bitset<D>,
+}
+impl<D: Dense> SparseUniverse<D> {
+    pub fn new(n: usize, valid: &'static Bitset<D>) -> Self { SparseUniverse { n, valid } }
+}
+impl<D: Dense> Query for SparseUniverse<D> { type D = D; type R = D; }
+impl<D: Dense> Drive for SparseUniverse<D> {
+    #[inline(always)]
+    fn drive<K: FnMut(D, D)>(&self, k: K) { self.valid.drive(k); }
+}
+impl<D: Dense> Probe for SparseUniverse<D> {
+    #[inline(always)]
+    fn probe<K: FnMut(D)>(&self, x: D, mut k: K) { if x.idx() < self.n { k(x); } }
+    #[inline(always)]
+    fn probe_any<K: FnMut(D) -> bool>(&self, x: D, mut k: K) -> bool { x.idx() < self.n && k(x) }
+    #[inline(always)]
+    fn member(&self, x: D) -> bool { x.idx() < self.n }
+}
+
+/// Exposes the size of a universe-like leaf so `Bitset::over` can be sized off
+/// either a dense `Universe` or a `SparseUniverse` handle.
+pub trait UnivSize<D: Dense> { fn univ_n(&self) -> usize; }
+impl<D: Dense> UnivSize<D> for Universe<D> { #[inline] fn univ_n(&self) -> usize { self.n } }
+impl<D: Dense> UnivSize<D> for SparseUniverse<D> { #[inline] fn univ_n(&self) -> usize { self.n } }
 
 // ===== GroupBy (Julia `r ← s`) — drive src, probe key per row ===========
 // For src: Drive<D, SV> and key: Probe<D, RK>, produces a drive-only

--- a/rust/src/schema.rs
+++ b/rust/src/schema.rs
@@ -71,7 +71,7 @@
 macro_rules! schema {
     // ===== entry: SCHEMA_MOD / StorageStruct / init_fn : entities... =====
     ( $mod_:ident / $store:ident / $init:ident :
-      $( $Ent:ident $( ( $uni:ident ) )? / $Nav:ident { $($body:tt)* } )* ) => {
+      $( $Ent:ident $( ( $uni:ident $($sp:ident)? ) )? / $Nav:ident { $($body:tt)* } )* ) => {
 
         $(
             #[allow(dead_code)]
@@ -103,7 +103,7 @@ macro_rules! schema {
             }
         }
 
-        $( $crate::schema::schema!(@uni $mod_; $Ent; [$($uni)?]; $($body)*); )*
+        $( $crate::schema::schema!(@uni $mod_; $Ent; [$($uni $($sp)?)?]; $($body)*); )*
         $( $crate::schema::schema!(@consts $mod_; $Ent; $Nav; $($body)*); )*
         $( $crate::schema::schema!(@nav $mod_; $Ent; $Nav; [] $($body)*); )*
         $( $crate::schema::schema!(@primary $mod_; $Ent; $($body)*); )*
@@ -263,6 +263,37 @@ macro_rules! schema {
             fn iq(self) -> Self::Q {
                 $crate::engine::Universe::new(
                     $mod_::STORE.get().expect("schema not initialized").$Ent.$ff.n_keys())
+            }
+        }
+    };
+
+    // ===== SPARSE universe handle: dense id space WITH holes (e.g. orders =====
+    // ===== over sparse orderkeys). Resolves to a `SparseUniverse` whose ======
+    // ===== drive skips holes; validity mask built lazily from the FIRST ======
+    // ===== field (which must be an FK — `NO_ID` marks a hole slot). ==========
+    (@uni $mod_:ident; $Ent:ident; [$uni:ident sparse]; pub $($rest:tt)*) => {
+        $crate::schema::schema!(@uni $mod_; $Ent; [$uni sparse]; $($rest)*);
+    };
+    (@uni $mod_:ident; $Ent:ident; [$uni:ident sparse];
+      $ff:ident : $t1:tt $(< $t2:tt >)? $(, $($rest:tt)*)? ) => {
+        /// Generated SPARSE universe HANDLE — resolves to a `SparseUniverse`
+        /// whose `drive` enumerates only live slots (the orderkey-gap holes are
+        /// masked out); `probe`/`member` keep the plain range check.
+        #[allow(non_camel_case_types, dead_code)]
+        #[derive(Clone, Copy)]
+        pub struct $uni;
+        impl $crate::engine::IntoQuery for $uni {
+            type Q = $crate::engine::SparseUniverse<$crate::engine::Id<$Ent>>;
+            #[inline]
+            fn iq(self) -> Self::Q {
+                static MASK: ::std::sync::OnceLock<
+                    $crate::engine::Bitset<$crate::engine::Id<$Ent>>> = ::std::sync::OnceLock::new();
+                let store = $mod_::STORE.get().expect("schema not initialized");
+                let n = store.$Ent.$ff.n_keys();
+                let mask = MASK.get_or_init(||
+                    $crate::engine::Bitset::<$crate::engine::Id<$Ent>>::validity(
+                        &store.$Ent.$ff.values));
+                $crate::engine::SparseUniverse::new(n, mask)
             }
         }
     };

--- a/rust/src/tpch/common.rs
+++ b/rust/src/tpch/common.rs
@@ -360,9 +360,11 @@ fn q12() -> String {
 // ---------- Q13 — customer distribution (LEFT JOIN) ----------
 
 fn q13() -> String {
+    // `orders` is a SPARSE universe — driving it skips the orderkey-gap holes,
+    // so the group key is the bare customer FK, no per-row validity guard.
     let count_per_cust = orders
         .with(Order::comment.nrx("special.*requests"))
-        .group_by(Order::customer.select(customer))   // semijoin real customers; drops orderkey-gap holes
+        .group_by(Order::customer)
         .dense_fold_outer(customer.iq().n, 0_i64, |a, _| a + 1);
     // Histogram: invert (c_count ← customer) and count customers per c_count.
     let dist = count_per_cust.inv().fold(0_i64, |a, _| a + 1);

--- a/rust/src/tpch_schema.rs
+++ b/rust/src/tpch_schema.rs
@@ -44,7 +44,7 @@ schema! { TPCH / TpchSchema / tpch_init:
         pub supplycost: f64,
         comment: str,
     }
-    Order(orders) / OrderNav {
+    Order(orders sparse) / OrderNav {
         customer: Customer,
         status: str,
         pub totalprice: f64,


### PR DESCRIPTION
TPC-H orderkeys are sparse, but the `orders` universe is dense over the max orderkey — ~75% of slots are NO_ID hole-fills. Driving it (q4, q13) visited those holes; q13 needed a per-row `Order::customer.select(...)` validity guard, and its comment regex ran over 6M slots not 1.5M.

Add SPARSE universes as a first-class, opt-in entity property:

- `SparseUniverse<D>` — a DISTINCT type from `Universe`: `drive` word-scans a validity Bitset (skips holes); `probe`/`member` keep the plain range check (a hole id never reaches a probe, so the mask is drive-only). Being a separate type means drive dispatch is at compile time — the dense `Universe::drive` loop is untouched, so its closure inlining isn't de-optimised (an earlier runtime-branch-in-Universe attempt regressed every universe scan ~16%).
- schema `sparse` marker — `Order(orders sparse)`. The @uni arm emits a SparseUniverse handle whose mask is built lazily from the first field (an FK; NO_ID marks a hole) via `Bitset::validity`. Generic/opt-in, so JOB is unaffected.
- `UnivSize` trait — `Bitset::over`/`empty` size off either universe kind, so `Bitset::over(orders, …)` still works with the now-sparse handle.

q13 drives the bare `orders` (no validity guard) — −20% (0.065→0.052s). Dense queries unchanged (±2% noise). 22/22 idiomatic + optimized at sf=1.