### PR TITLE
Make Member a supertrait of Probe

### DIFF
--- a/rust/src/engine.rs
+++ b/rust/src/engine.rs
@@ -4,8 +4,9 @@
 //
 //   Query    { type D; type R; }              — a binary relation D → R
 //   Drive:  Query + fn drive(&self, k)        — can be scanned (k(d, r) per pair)
-//   Probe:  Query + fn probe / probe_any      — can be looked up by key
 //   Member: Query + fn member                 — domain-membership test
+//   Probe:  Member + fn probe / probe_any     — can be looked up by key
+//                                               (⟹ member-testable)
 //
 // There is no separate key-set family: a set IS an identity relation D → D
 // (Julia's `Unary{D} <: Query{D, D}`). Set-shaped nodes (Universe, Bitset,
@@ -73,18 +74,25 @@ pub trait Drive: Query {
     fn drive<K: FnMut(Self::D, Self::R)>(&self, k: K);
 }
 
-pub trait Probe: Query {
-    fn probe<K: FnMut(Self::R)>(&self, x: Self::D, k: K);
-    fn probe_any<K: FnMut(Self::R) -> bool>(&self, x: Self::D, k: K) -> bool;
-}
-
 /// Domain-membership test — "is `x` in the domain of this relation?".
-/// A mode of its own (NOT part of `Probe`): member-position combinators
-/// (`Restrict`'s / `Diff`'s rhs, `Disj`'s legs) bound their operands on
-/// `Member` only, so member-only nodes like `Disj` compose there without
-/// pretending to probe.
+/// A mode of its own, and the weakest of the lookup modes:
+/// member-position combinators (`Restrict`'s / `Diff`'s rhs, `Disj`'s
+/// legs) bound their operands on `Member` only, so member-only nodes like
+/// `Disj` compose there without pretending to probe.
 pub trait Member: Query {
     fn member(&self, x: Self::D) -> bool;
+}
+
+/// `Member` is a supertrait: probing strictly exceeds membership
+/// (`probe_any` with a trivially-true continuation decides it), so every
+/// probe-able node MUST say how it member-tests — one `member_via_probe!`
+/// line for the universal default, or a hand-written override. Forgetting
+/// is a compile error at the `impl Probe`, not a puzzle at some distant
+/// member-position use site. The converse does not hold (`Disj` is
+/// `Member` without `Probe`).
+pub trait Probe: Member {
+    fn probe<K: FnMut(Self::R)>(&self, x: Self::D, k: K);
+    fn probe_any<K: FnMut(Self::R) -> bool>(&self, x: Self::D, k: K) -> bool;
 }
 
 /// Opt a probe-able type into the universal `member` definition

--- a/rust/src/queries/helpers.rs
+++ b/rust/src/queries/helpers.rs
@@ -53,7 +53,7 @@ pub fn min_row<Q: Drive>(q: Q) -> String where Q::R: Row {
 
 /// Companies named *Film*/*Warner*, non-Polish production companies without
 /// a note — the `co` binding of queries 21a-c and 27a-c.
-pub fn film_or_warner_co() -> impl Query<R = Id<Company>, D = Id<Movie>> + Drive + Probe + Member {
+pub fn film_or_warner_co() -> impl Query<R = Id<Company>, D = Id<Movie>> + Drive + Probe {
     company.with(country.ne("[pl]")
             .and(Company::name.rx(r"Film").or(Company::name.rx(r"Warner")))
             .and(Company::ty.eq("production companies").minus(Company::note)))
@@ -63,6 +63,6 @@ pub fn film_or_warner_co() -> impl Query<R = Id<Company>, D = Id<Movie>> + Drive
 /// links — the `lk` binding of queries 21a-c and 27a-c. String-valued like
 /// Julia's `link → (MovieLink.type ~ r"follow")` (whose primary elision
 /// composes through to `LinkType.link`), so output products use it directly.
-pub fn follow_link() -> impl Query<D = Id<Movie>, R = &'static str> + Drive + Probe + Member {
+pub fn follow_link() -> impl Query<D = Id<Movie>, R = &'static str> + Drive + Probe {
     link.select(MovieLink::ty.rx(r"follow"))
 }

--- a/rust/src/queries/t3.rs
+++ b/rust/src/queries/t3.rs
@@ -54,7 +54,7 @@ fn q7b() -> impl Drive<R: Row> {
 
 // Conjunct tree (∧ = Prod) — consumed via `member` only, so the value
 // type stays opaque (`impl Query<D = Id<PersonInfo>> + Probe`).
-fn bio_filter_7c() -> impl Query<D = Id<PersonInfo>> + Probe + Member {
+fn bio_filter_7c() -> impl Query<D = Id<PersonInfo>> + Probe {
     PersonInfo::ty.eq("mini biography")
         .and(PersonInfo::note)
 }

--- a/rust/src/queries/t4.rs
+++ b/rust/src/queries/t4.rs
@@ -73,7 +73,7 @@ fn q17e() -> impl Drive<R: Row> {
        .select(cast.person().name())
 }
 
-fn ib_18a() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe + Member {
+fn ib_18a() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe {
     info.with(Info::ty.eq("budget")).info()
 }
 
@@ -89,7 +89,7 @@ fn q18a() -> impl Drive<R: Row> {
 
 // Conjunct/diff tree (∧ = Prod, - = Diff) — consumed via `member` only, so
 // the value type stays opaque (`impl Query<D = Id<Info>> + Probe`).
-fn gf_18b() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_18b() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.is_in(["Horror", "Thriller"]))
         .minus(Info::note)
@@ -107,7 +107,7 @@ fn q18b() -> impl Drive<R: Row> {
           .and(title))
 }
 
-fn gf_18c() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_18c() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.is_in(genre6()))
 }

--- a/rust/src/queries/t5.rs
+++ b/rust/src/queries/t5.rs
@@ -6,23 +6,23 @@ use crate::queries::helpers::{min_row, Row};
 use crate::queries::sets::{genre6, kw7, kw8, kw10, nordic8, nordic9, voice4, writer5};
 use super::helpers::{film_or_warner_co, follow_link};
 
-fn k_23ab() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe + Member {
+fn k_23ab() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe {
     kind.eq("movie")
 }
 
-fn k_23c() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe + Member {
+fn k_23c() -> impl Query<R = &'static str, D = Id<Movie>> + Drive + Probe {
     kind.text()
         .is_in(["movie", "tv movie", "video movie", "video game"])
 }
 
 // Conjunct trees (∧ = Prod) — consumed via `member` only, so the value
 // type stays opaque (`impl Query<D = Id<Info>> + Probe`).
-fn gf_25ab() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_25ab() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.eq("Horror"))
 }
 
-fn gf_25c() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_25c() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.is_in(genre6()))
 }

--- a/rust/src/queries/t6.rs
+++ b/rust/src/queries/t6.rs
@@ -6,35 +6,35 @@ use crate::queries::helpers::{min_row, Row};
 use crate::queries::sets::{genre6, kw7, link3, murder4, nordic9, nordic10, voice3, voice4, writer5};
 use super::helpers::{film_or_warner_co, follow_link};
 
-fn co_28() -> impl Query<R = Id<Company>, D = Id<Movie>> + Drive + Probe + Member {
+fn co_28() -> impl Query<R = Id<Company>, D = Id<Movie>> + Drive + Probe {
     company.with(country.ne("[us]")
             .and(Company::note.nrx(r"\(USA\)"))
             .and(Company::note.rx(r"\(200.*\)")))
 }
 
-fn dt_28ac() -> impl Query<R = Id<Data>, D = Id<Movie>> + Drive + Probe + Member {
+fn dt_28ac() -> impl Query<R = Id<Data>, D = Id<Movie>> + Drive + Probe {
     data.with(Data::ty.eq("rating")
          .and(Data::text.lt("8.5")))
 }
 
-fn dt_28b() -> impl Query<R = Id<Data>, D = Id<Movie>> + Drive + Probe + Member {
+fn dt_28b() -> impl Query<R = Id<Data>, D = Id<Movie>> + Drive + Probe {
     data.with(Data::ty.eq("rating")
          .and(Data::text.gt("6.5")))
 }
 
 // Conjunct trees (∧ = Prod) — consumed via `member` only, so the value
 // type stays opaque (`impl Query<D = Id<Info>> + Probe`).
-fn gf_horror() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_horror() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.is_in(["Horror", "Thriller"]))
 }
 
-fn gf_genre6() -> impl Query<D = Id<Info>> + Probe + Member {
+fn gf_genre6() -> impl Query<D = Id<Info>> + Probe {
     Info::ty.eq("genres")
         .and(Info::info.is_in(genre6()))
 }
 
-fn qlink_33a() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe + Member {
+fn qlink_33a() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe {
     link.with(MovieLink::ty.is_in(link3())
          .and(target.with(kind.eq("tv series")
                      .and(company)
@@ -44,7 +44,7 @@ fn qlink_33a() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe +
                      .and(production_year.le(2008)))))
 }
 
-fn qlink_33b() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe + Member {
+fn qlink_33b() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe {
     link.with(MovieLink::ty.rx(r"follow")
          .and(target.with(kind.eq("tv series")
                      .and(company)
@@ -53,7 +53,7 @@ fn qlink_33b() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe +
                      .and(production_year.eq(2007)))))
 }
 
-fn qlink_33c() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe + Member {
+fn qlink_33c() -> impl Query<R = Id<MovieLink>, D = Id<Movie>> + Drive + Probe {
     link.with(MovieLink::ty.is_in(link3())
          .and(target.with(kind.is_in(["tv series", "episode"])
                      .and(company)


### PR DESCRIPTION
Probing strictly exceeds membership (probe_any with a trivially-true continuation decides it), so every probe-able node must say how it member-tests: one member_via_probe! line for the default, or an override. Forgetting is now a compile error at the impl Probe rather than an unsatisfied bound at a distant member-position use site, and B: Probe bounds get member for free — the queries' opaque return types drop their redundant + Member.